### PR TITLE
Fix %points% outputting total points instead of points recieved

### DIFF
--- a/src/main/java/universalDiscord/UniversalDiscordPlugin.java
+++ b/src/main/java/universalDiscord/UniversalDiscordPlugin.java
@@ -65,7 +65,7 @@ public class UniversalDiscordPlugin extends Plugin {
 
     private static final Pattern CLUE_SCROLL_REGEX = Pattern.compile("You have completed (?<scrollCount>\\d+) (?<scrollType>\\w+) Treasure Trails\\.");
     private static final Pattern SLAYER_TASK_REGEX = Pattern.compile("You have completed your task! You killed (?<task>[\\d,]+ [\\w,]+)\\..*");
-    private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received \\d+ points, giving you a total of (?<points>[\\d,]+)|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
+    private static final Pattern SLAYER_COMPLETE_REGEX = Pattern.compile("You've completed (?:at least )?(?<taskCount>[\\d,]+) (?:Wilderness )?tasks?(?: and received (?<points>\\d+) points, giving you a total of [\\d,]+|\\.You'll be eligible to earn reward points if you complete tasks from a more advanced Slayer Master\\.| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 
     private static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>[\\w,\\s-.]+)");
     private static final Pattern PET_REGEX = Pattern.compile("You have a funny feeling like you.*");


### PR DESCRIPTION
As noted in the README - %points% is supposed to output the recieved points, but currently it outputs your total points.
https://github.com/MidgetJake/UniversalDiscordNotifier/blob/10c72cae85a2f8935b086ba64fc0cd9d70c0ba63/README.md?plain=1#L58

This moves the <points> declaration in SLAYER_COMPLETE_REGEX