### PR TITLE
Added a simple test for collection log regex. Fixed regex now works with ' and () in item names.

### DIFF
--- a/src/main/java/universalDiscord/notifiers/CollectionNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/CollectionNotifier.java
@@ -12,7 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CollectionNotifier extends BaseNotifier implements ChatMessageHandler {
-    private static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>[\\w,\\s-.]+)");
+    public static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>[\\w,\\s-.'()]+)");
 
     private Matcher lastMatcher;
 

--- a/src/test/java/universalDiscord/CollectionNotifierTest.java
+++ b/src/test/java/universalDiscord/CollectionNotifierTest.java
@@ -15,7 +15,7 @@ public class CollectionNotifierTest {
     @Test
     public void testCollectionLogRegex() {
         String[] itemNames = {
-                "Xerics talisman",
+                "Xeric's talisman (inert)",
                 "Jar of miasma",
                 "Saradomin's light",
                 "Craw's bow",

--- a/src/test/java/universalDiscord/CollectionNotifierTest.java
+++ b/src/test/java/universalDiscord/CollectionNotifierTest.java
@@ -1,0 +1,38 @@
+package universalDiscord;
+
+import org.junit.Test;
+import universalDiscord.notifiers.CollectionNotifier;
+
+import java.util.regex.Matcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class CollectionNotifierTest {
+
+
+    @Test
+    public void testCollectionLogRegex() {
+        String[] itemNames = {
+                "Xerics talisman",
+                "Jar of miasma",
+                "Saradomin's light",
+                "Craw's bow",
+                "Thammaron's sceptre",
+                "Chompy bird hat (ogre yeoman)",
+                "Robe bottoms of the eye",
+                "Bucket helm (g)",
+                "Black d'hide body (g)",
+                "Tzhaar-ket-om ornament kit",
+        };
+
+        for (String itemName : itemNames) {
+            String chatLine = "New item added to your collection log: " + itemName;
+            Matcher matcher = CollectionNotifier.COLLECTION_LOG_REGEX.matcher(chatLine);
+            boolean finds = matcher.find();
+            assertTrue(finds);
+            assertEquals(itemName, matcher.group("itemName"));
+        }
+    }
+}


### PR DESCRIPTION
Item names like "Xeric's talisman" would be cut at the apostrophe
<img width="445" alt="Screenshot 2022-11-12 at 21 33 46" src="https://user-images.githubusercontent.com/17124771/201493549-d3d9f85d-42ff-4c5b-9617-b9c374c15e8f.png">
