### PR TITLE
Fixed death notifcation when monster dies and has same name as the player.

### DIFF
--- a/src/main/java/universalDiscord/notifiers/DeathNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/DeathNotifier.java
@@ -30,9 +30,16 @@ public class DeathNotifier extends BaseNotifier {
     @Override
     public boolean shouldNotify() {
         return isEnabled()
-                && lastActorDeath != null
-                && lastActorDeath.getActor() instanceof Player
-                && Objects.equals(((Player) lastActorDeath.getActor()).getId(), plugin.client.getLocalPlayer().getId());
+                && lastActorDeathIsLocalPlayer();
+    }
+
+    public boolean lastActorDeathIsLocalPlayer() {
+        if (lastActorDeath != null && lastActorDeath.getActor() instanceof Player) {
+            Player lastPlayerDeath = (Player) lastActorDeath.getActor();
+            return Objects.equals(lastPlayerDeath.getId(), plugin.client.getLocalPlayer().getId());
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/universalDiscord/notifiers/DeathNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/DeathNotifier.java
@@ -34,9 +34,8 @@ public class DeathNotifier extends BaseNotifier {
     }
 
     public boolean lastActorDeathIsLocalPlayer() {
-        if (lastActorDeath != null && lastActorDeath.getActor() instanceof Player) {
-            Player lastPlayerDeath = (Player) lastActorDeath.getActor();
-            return Objects.equals(lastPlayerDeath.getId(), plugin.client.getLocalPlayer().getId());
+        if (lastActorDeath != null) {
+            return Objects.equals(lastActorDeath.getActor(), plugin.client.getLocalPlayer());
         }
 
         return false;

--- a/src/main/java/universalDiscord/notifiers/DeathNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/DeathNotifier.java
@@ -1,5 +1,6 @@
 package universalDiscord.notifiers;
 
+import net.runelite.api.Player;
 import net.runelite.api.events.ActorDeath;
 import universalDiscord.UniversalDiscordPlugin;
 import universalDiscord.Utils;
@@ -30,7 +31,8 @@ public class DeathNotifier extends BaseNotifier {
     public boolean shouldNotify() {
         return isEnabled()
                 && lastActorDeath != null
-                && Objects.equals(lastActorDeath.getActor().getName(), Utils.getPlayerName());
+                && lastActorDeath.getActor() instanceof Player
+                && Objects.equals(((Player) lastActorDeath.getActor()).getId(), plugin.client.getLocalPlayer().getId());
     }
 
     @Override


### PR DESCRIPTION
Fixes [https://github.com/MidgetJake/UniversalDiscordNotifier/issues/10](https://github.com/MidgetJake/UniversalDiscordNotifier/issues/10)