### PR TITLE
Bugfix/duplicate clue notification

### DIFF
--- a/src/main/java/universalDiscord/DeathThumbnail.java
+++ b/src/main/java/universalDiscord/DeathThumbnail.java
@@ -1,0 +1,14 @@
+package universalDiscord;
+
+public enum DeathThumbnail {
+    NONE(null),
+    DEATH("https://oldschool.runescape.wiki/images/Death.png"),
+    GRAVE("https://oldschool.runescape.wiki/images/Grave.png"),
+    ANGEL_GRAVE("https://oldschool.runescape.wiki/images/Grave_%28Angel%29.png");
+
+    public final String thumbnailUrl;
+
+    DeathThumbnail(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+    }
+}

--- a/src/main/java/universalDiscord/DeathThumbnail.java
+++ b/src/main/java/universalDiscord/DeathThumbnail.java
@@ -4,6 +4,7 @@ public enum DeathThumbnail {
     NONE(null),
     DEATH("https://oldschool.runescape.wiki/images/Death.png"),
     GRAVE("https://oldschool.runescape.wiki/images/Grave.png"),
+    BONES("https://oldschool.runescape.wiki/images/Bones_detail.png"),
     ANGEL_GRAVE("https://oldschool.runescape.wiki/images/Grave_%28Angel%29.png");
 
     public final String thumbnailUrl;

--- a/src/main/java/universalDiscord/ItemSearcher.java
+++ b/src/main/java/universalDiscord/ItemSearcher.java
@@ -1,0 +1,73 @@
+package universalDiscord;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+final public class ItemSearcher {
+    @Inject
+    private OkHttpClient okHttpClient;
+    private Map<String, Integer> nameAndIds = new HashMap<>();
+
+    public void loadItemIdsAndNames() {
+        Request request = new Request.Builder().url("https://static.runelite.net/cache/item/names.json").build();
+        okHttpClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                log.warn("Failed to load item names and ids.");
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) {
+                Gson gson = new Gson();
+                try {
+                    Map<String, String> items = gson.fromJson(response.body().charStream(), Map.class);
+                    filterNotedItems(items);
+                } catch (JsonSyntaxException | JsonIOException e) {
+                    log.error("UniversalDiscord failed to load names");
+                }
+            }
+        });
+    }
+
+    private void filterNotedItems(Map<String, String> items) {
+        Request request = new Request.Builder().url("https://static.runelite.net/cache/item/notes.json").build();
+        okHttpClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                log.warn("Failed to remove noted items.");
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                Gson gson = new Gson();
+                try {
+                    Map<String, String> notes = gson.fromJson(response.body().charStream(), Map.class);
+                    notes.keySet().forEach(items::remove);
+                } catch (JsonSyntaxException | JsonIOException e) {
+                    log.error("UniversalDiscord failed to filter noted items");
+                }
+                // Always set the items even when failing to filter noted items.
+                nameAndIds = items
+                        .entrySet()
+                        .stream()
+                        .collect(
+                                Collectors.toMap(Map.Entry::getValue, (e) -> Integer.parseInt(e.getKey()), (Integer a, Integer b) -> a)
+                        );
+            }
+        });
+    }
+
+    public Integer findItemId(String name) {
+        return nameAndIds.get(name);
+    }
+}

--- a/src/main/java/universalDiscord/UniversalDiscordConfig.java
+++ b/src/main/java/universalDiscord/UniversalDiscordConfig.java
@@ -4,6 +4,8 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
+import universalDiscord.enums.DeathThumbnail;
+import universalDiscord.enums.PlayerUrlService;
 
 @ConfigGroup("universalDiscord")
 public interface UniversalDiscordConfig extends Config {

--- a/src/main/java/universalDiscord/UniversalDiscordConfig.java
+++ b/src/main/java/universalDiscord/UniversalDiscordConfig.java
@@ -250,21 +250,10 @@ public interface UniversalDiscordConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "deathThumbnail",
-            name = "Thumbnail to use",
-            description = "Send a thumbnail with the notification",
-            position = 2,
-            section = deathSection
-    )
-    default DeathThumbnail deathThumbnail() {
-        return DeathThumbnail.DEATH;
-    }
-
-    @ConfigItem(
             keyName = "deathSendImage",
             name = "Send Image",
             description = "Send image with the notification",
-            position = 3,
+            position = 2,
             section = deathSection
     )
     default boolean deathSendImage() {
@@ -272,10 +261,21 @@ public interface UniversalDiscordConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "deathThumbnail",
+            name = "Thumbnail to use",
+            description = "Send a thumbnail with the notification",
+            position = 3,
+            section = deathSection
+    )
+    default DeathThumbnail deathThumbnail() {
+        return DeathThumbnail.DEATH;
+    }
+
+    @ConfigItem(
             keyName = "deathNotifMessage",
             name = "Notification Message",
             description = "The message to be sent through the webhook. Use %USERNAME% to insert your username",
-            position = 3,
+            position = 4,
             section = deathSection
     )
     default String deathNotifyMessage() {

--- a/src/main/java/universalDiscord/UniversalDiscordConfig.java
+++ b/src/main/java/universalDiscord/UniversalDiscordConfig.java
@@ -250,10 +250,21 @@ public interface UniversalDiscordConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "deathThumbnail",
+            name = "Thumbnail to use",
+            description = "Send a thumbnail with the notification",
+            position = 2,
+            section = deathSection
+    )
+    default DeathThumbnail deathThumbnail() {
+        return DeathThumbnail.DEATH;
+    }
+
+    @ConfigItem(
             keyName = "deathSendImage",
             name = "Send Image",
             description = "Send image with the notification",
-            position = 2,
+            position = 3,
             section = deathSection
     )
     default boolean deathSendImage() {

--- a/src/main/java/universalDiscord/UniversalDiscordPlugin.java
+++ b/src/main/java/universalDiscord/UniversalDiscordPlugin.java
@@ -1,5 +1,6 @@
 package universalDiscord;
 
+import com.google.inject.Guice;
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
@@ -12,12 +13,10 @@ import net.runelite.client.events.NotificationFired;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.PlayerLootReceived;
 import net.runelite.client.game.ItemManager;
-import net.runelite.client.game.WorldService;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.loottracker.LootReceived;
 import net.runelite.client.ui.DrawManager;
-import net.runelite.http.api.worlds.WorldResult;
 import okhttp3.OkHttpClient;
 import universalDiscord.message.DiscordMessageHandler;
 import universalDiscord.notifiers.*;
@@ -43,6 +42,9 @@ public class UniversalDiscordPlugin extends Plugin {
     @Inject
     public ItemManager itemManager;
 
+    @Inject
+    public ItemSearcher itemSearcher;
+
     public final DiscordMessageHandler messageHandler = new DiscordMessageHandler(this);
     private final CollectionNotifier collectionNotifier = new CollectionNotifier(this);
     private final PetNotifier petNotifier = new PetNotifier(this);
@@ -57,6 +59,8 @@ public class UniversalDiscordPlugin extends Plugin {
     @Override
     protected void startUp() {
         Utils.plugin = this;
+        itemSearcher.loadItemIdsAndNames();
+
         log.info("Started up Universal Discord");
     }
 

--- a/src/main/java/universalDiscord/enums/ClueType.java
+++ b/src/main/java/universalDiscord/enums/ClueType.java
@@ -1,9 +1,11 @@
-package universalDiscord;
+package universalDiscord.enums;
 
 import net.runelite.api.ItemID;
+import universalDiscord.Utils;
 import universalDiscord.message.discord.Image;
 
-public enum ClueType {
+@SuppressWarnings("unused")
+public enum ClueType implements ThumbnailUrl {
     BEGINNER(ItemID.REWARD_CASKET_BEGINNER),
     EASY(ItemID.REWARD_CASKET_EASY),
     MEDIUM(ItemID.REWARD_CASKET_MEDIUM),
@@ -18,10 +20,15 @@ public enum ClueType {
     }
 
     public Image getCasketImage() {
-        return new Image(Utils.getItemImageUrl(casketItemId));
+        return new Image(this.getThumbnailUrl());
     }
 
     public String getMarkdownWikiUrl() {
         return Utils.asMarkdownWikiUrl(this.name().toLowerCase().concat(" clue"), this.name().toLowerCase());
+    }
+
+    @Override
+    public String getThumbnailUrl() {
+        return Utils.getItemImageUrl(casketItemId);
     }
 }

--- a/src/main/java/universalDiscord/enums/DeathThumbnail.java
+++ b/src/main/java/universalDiscord/enums/DeathThumbnail.java
@@ -1,15 +1,21 @@
-package universalDiscord;
+package universalDiscord.enums;
 
-public enum DeathThumbnail {
+@SuppressWarnings("unused")
+public enum DeathThumbnail implements ThumbnailUrl {
     NONE(null),
     DEATH("https://oldschool.runescape.wiki/images/Death.png"),
     GRAVE("https://oldschool.runescape.wiki/images/Grave.png"),
     BONES("https://oldschool.runescape.wiki/images/Bones_detail.png"),
     ANGEL_GRAVE("https://oldschool.runescape.wiki/images/Grave_%28Angel%29.png");
 
-    public final String thumbnailUrl;
+    private final String thumbnailUrl;
 
     DeathThumbnail(String thumbnailUrl) {
         this.thumbnailUrl = thumbnailUrl;
+    }
+
+    @Override
+    public String getThumbnailUrl() {
+        return this.thumbnailUrl;
     }
 }

--- a/src/main/java/universalDiscord/enums/PlayerUrlService.java
+++ b/src/main/java/universalDiscord/enums/PlayerUrlService.java
@@ -1,4 +1,4 @@
-package universalDiscord;
+package universalDiscord.enums;
 
 public enum PlayerUrlService {
     NONE("None"),

--- a/src/main/java/universalDiscord/enums/SkillThumbnail.java
+++ b/src/main/java/universalDiscord/enums/SkillThumbnail.java
@@ -1,0 +1,43 @@
+package universalDiscord.enums;
+
+@SuppressWarnings("unused")
+public enum SkillThumbnail implements ThumbnailUrl {
+    ATTACK("https://oldschool.runescape.wiki/images/Attack_icon_%28detail%29.png"),
+    DEFENCE("https://oldschool.runescape.wiki/images/Defence_icon_%28detail%29.png"),
+    STRENGTH("https://oldschool.runescape.wiki/images/Strength_icon_%28detail%29.png"),
+    HITPOINTS("https://oldschool.runescape.wiki/images/Hitpoints_icon_%28detail%29.png"),
+    RANGED("https://oldschool.runescape.wiki/images/Ranged_icon_%28detail%29.png"),
+    PRAYER("https://oldschool.runescape.wiki/images/Prayer_icon_%28detail%29.png"),
+    MAGIC("https://oldschool.runescape.wiki/images/Magic_icon_%28detail%29.png"),
+    COOKING("https://oldschool.runescape.wiki/images/Cooking_icon_%28detail%29.png"),
+    WOODCUTTING("https://oldschool.runescape.wiki/images/Woodcutting_icon_%28detail%29.png"),
+    FLETCHING("https://oldschool.runescape.wiki/images/Fletching_icon_%28detail%29.png"),
+    FISHING("https://oldschool.runescape.wiki/images/Fishing_icon_%28detail%29.png"),
+    FIREMAKING("https://oldschool.runescape.wiki/images/Firemaking_icon_%28detail%29.png"),
+    CRAFTING("https://oldschool.runescape.wiki/images/Crafting_icon_%28detail%29.png"),
+    SMITHING("https://oldschool.runescape.wiki/images/Smithing_icon_%28detail%29.png"),
+    MINING("https://oldschool.runescape.wiki/images/Mining_icon_%28detail%29.png"),
+    HERBLORE("https://oldschool.runescape.wiki/images/Herblore_icon_%28detail%29.png"),
+    AGILITY("https://oldschool.runescape.wiki/images/Agility_icon_%28detail%29.png"),
+    THIEVING("https://oldschool.runescape.wiki/images/Thieving_icon_%28detail%29.png"),
+    SLAYER("https://oldschool.runescape.wiki/images/Slayer_icon_%28detail%29.png"),
+    FARMING("https://oldschool.runescape.wiki/images/Farming_icon_%28detail%29.png"),
+    RUNECRAFT("https://oldschool.runescape.wiki/images/Runecraft_icon_%28detail%29.png"),
+    HUNTER("https://oldschool.runescape.wiki/images/Hunter_icon_%28detail%29.png"),
+    CONSTRUCTION("https://oldschool.runescape.wiki/images/Construction_icon_%28detail%29.png"),
+    /**
+     * The level of all skills added together.
+     */
+    OVERALL("https://oldschool.runescape.wiki/images/Stats_icon.png");
+
+    private final String thumbnailUrl;
+
+    SkillThumbnail(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    @Override
+    public String getThumbnailUrl() {
+        return this.thumbnailUrl;
+    }
+}

--- a/src/main/java/universalDiscord/enums/ThumbnailUrl.java
+++ b/src/main/java/universalDiscord/enums/ThumbnailUrl.java
@@ -1,0 +1,5 @@
+package universalDiscord.enums;
+
+public interface ThumbnailUrl {
+    String getThumbnailUrl();
+}

--- a/src/main/java/universalDiscord/message/DiscordMessageHandler.java
+++ b/src/main/java/universalDiscord/message/DiscordMessageHandler.java
@@ -8,7 +8,6 @@ import okhttp3.*;
 import okhttp3.internal.annotations.EverythingIsNonNull;
 import universalDiscord.UniversalDiscordPlugin;
 import universalDiscord.Utils;
-import universalDiscord.message.discord.Embed;
 import universalDiscord.message.discord.Image;
 
 import javax.inject.Inject;

--- a/src/main/java/universalDiscord/message/MessageBuilder.java
+++ b/src/main/java/universalDiscord/message/MessageBuilder.java
@@ -4,6 +4,7 @@ import lombok.NonNull;
 import universalDiscord.Utils;
 import universalDiscord.message.discord.Author;
 import universalDiscord.message.discord.Embed;
+import universalDiscord.message.discord.Image;
 import universalDiscord.message.discord.WebhookBody;
 
 public class MessageBuilder {
@@ -24,6 +25,10 @@ public class MessageBuilder {
     public MessageBuilder(WebhookBody webhookBody, boolean sendScreenImage) {
         this.webhookBody = webhookBody;
         this.sendScreenImage = sendScreenImage;
+    }
+
+    public void setFirstThumbnail(Image image) {
+        webhookBody.getEmbeds().stream().findFirst().ifPresent((embed -> embed.setThumbnail(image)));
     }
 
     public void setPlayerAsAuthorForEmbeds() {

--- a/src/main/java/universalDiscord/notifiers/ClueNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/ClueNotifier.java
@@ -1,7 +1,6 @@
 package universalDiscord.notifiers;
 
 import net.runelite.api.ItemComposition;
-import net.runelite.api.ItemID;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
@@ -9,7 +8,7 @@ import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.util.QuantityFormatter;
 import net.runelite.client.util.Text;
-import universalDiscord.ClueType;
+import universalDiscord.enums.ClueType;
 import universalDiscord.UniversalDiscordPlugin;
 import universalDiscord.Utils;
 import universalDiscord.message.MessageBuilder;

--- a/src/main/java/universalDiscord/notifiers/CollectionNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/CollectionNotifier.java
@@ -1,6 +1,5 @@
 package universalDiscord.notifiers;
 
-import net.runelite.api.ItemID;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.client.util.Text;
 import universalDiscord.UniversalDiscordPlugin;

--- a/src/main/java/universalDiscord/notifiers/CollectionNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/CollectionNotifier.java
@@ -1,10 +1,12 @@
 package universalDiscord.notifiers;
 
+import net.runelite.api.ItemID;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.client.util.Text;
 import universalDiscord.UniversalDiscordPlugin;
 import universalDiscord.Utils;
 import universalDiscord.message.MessageBuilder;
+import universalDiscord.message.discord.Image;
 import universalDiscord.notifiers.onevent.ChatMessageHandler;
 
 import javax.inject.Inject;
@@ -32,10 +34,16 @@ public class CollectionNotifier extends BaseNotifier implements ChatMessageHandl
     }
 
     public void handleNotify() {
+        String itemName = lastMatcher.group("itemName");
         String notifyMessage = Utils.replaceCommonPlaceholders(plugin.config.collectionNotifyMessage())
-                .replaceAll("%ITEM%", Utils.asMarkdownWikiUrl(lastMatcher.group("itemName")));
+                .replaceAll("%ITEM%", Utils.asMarkdownWikiUrl(itemName));
 
         MessageBuilder messageBuilder = MessageBuilder.textAsEmbed(notifyMessage, plugin.config.collectionSendImage());
+        Integer itemId = plugin.itemSearcher.findItemId(itemName);
+        if (itemId != null) {
+            messageBuilder.setFirstThumbnail(new Image(Utils.getItemImageUrl(itemId)));
+        }
+
         plugin.messageHandler.sendMessage(messageBuilder);
 
         reset();

--- a/src/main/java/universalDiscord/notifiers/CollectionNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/CollectionNotifier.java
@@ -12,7 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CollectionNotifier extends BaseNotifier implements ChatMessageHandler {
-    private static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>[\\w,\\s-.]+)");
+    public static final Pattern COLLECTION_LOG_REGEX = Pattern.compile("New item added to your collection log: (?<itemName>[\\w,\\s-.'()]+)");
 
     private Matcher lastMatcher;
 

--- a/src/main/java/universalDiscord/notifiers/DeathNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/DeathNotifier.java
@@ -1,8 +1,7 @@
 package universalDiscord.notifiers;
 
-import net.runelite.api.Player;
 import net.runelite.api.events.ActorDeath;
-import universalDiscord.DeathThumbnail;
+import universalDiscord.enums.DeathThumbnail;
 import universalDiscord.UniversalDiscordPlugin;
 import universalDiscord.Utils;
 import universalDiscord.message.MessageBuilder;
@@ -24,7 +23,7 @@ public class DeathNotifier extends BaseNotifier {
         String notifyMessage = Utils.replaceCommonPlaceholders(plugin.config.deathNotifyMessage());
 
         MessageBuilder messageBuilder = MessageBuilder.textAsEmbed(notifyMessage, plugin.config.deathSendImage());
-        String thumbnailUrl = deathThumbNail().thumbnailUrl;
+        String thumbnailUrl = deathThumbNail().getThumbnailUrl();
         if (thumbnailUrl != null) {
             messageBuilder.webhookBody.getEmbeds().stream().findFirst().ifPresent((embed -> embed.setThumbnail(new Image(thumbnailUrl))));
         }

--- a/src/main/java/universalDiscord/notifiers/DeathNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/DeathNotifier.java
@@ -30,9 +30,16 @@ public class DeathNotifier extends BaseNotifier {
     @Override
     public boolean shouldNotify() {
         return isEnabled()
-                && lastActorDeath != null
-                && lastActorDeath.getActor() instanceof Player
-                && Objects.equals(((Player) lastActorDeath.getActor()).getId(), plugin.client.getLocalPlayer().getId());
+                && lastActorDeathIsLocalPlayer();
+    }
+
+    public boolean lastActorDeathIsLocalPlayer() {
+        if (lastActorDeath != null && lastActorDeath.getActor() instanceof Player) {
+            Player lastPlayerDeath = (Player) lastActorDeath.getActor();
+            return Objects.equals(lastPlayerDeath.getId(), plugin.client.getLocalPlayer().getId());
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/universalDiscord/notifiers/DeathNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/DeathNotifier.java
@@ -2,9 +2,11 @@ package universalDiscord.notifiers;
 
 import net.runelite.api.Player;
 import net.runelite.api.events.ActorDeath;
+import universalDiscord.DeathThumbnail;
 import universalDiscord.UniversalDiscordPlugin;
 import universalDiscord.Utils;
 import universalDiscord.message.MessageBuilder;
+import universalDiscord.message.discord.Image;
 
 import javax.inject.Inject;
 import java.util.Objects;
@@ -22,6 +24,10 @@ public class DeathNotifier extends BaseNotifier {
         String notifyMessage = Utils.replaceCommonPlaceholders(plugin.config.deathNotifyMessage());
 
         MessageBuilder messageBuilder = MessageBuilder.textAsEmbed(notifyMessage, plugin.config.deathSendImage());
+        String thumbnailUrl = deathThumbNail().thumbnailUrl;
+        if (thumbnailUrl != null) {
+            messageBuilder.webhookBody.getEmbeds().stream().findFirst().ifPresent((embed -> embed.setThumbnail(new Image(thumbnailUrl))));
+        }
         plugin.messageHandler.sendMessage(messageBuilder);
 
         reset();
@@ -39,6 +45,10 @@ public class DeathNotifier extends BaseNotifier {
         }
 
         return false;
+    }
+
+    public DeathThumbnail deathThumbNail() {
+        return plugin.config.deathThumbnail();
     }
 
     @Override

--- a/src/main/java/universalDiscord/notifiers/DeathNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/DeathNotifier.java
@@ -34,9 +34,8 @@ public class DeathNotifier extends BaseNotifier {
     }
 
     public boolean lastActorDeathIsLocalPlayer() {
-        if (lastActorDeath != null && lastActorDeath.getActor() instanceof Player) {
-            Player lastPlayerDeath = (Player) lastActorDeath.getActor();
-            return Objects.equals(lastPlayerDeath.getId(), plugin.client.getLocalPlayer().getId());
+        if (lastActorDeath != null) {
+            return Objects.equals(lastActorDeath.getActor(), plugin.client.getLocalPlayer());
         }
 
         return false;

--- a/src/main/java/universalDiscord/notifiers/DeathNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/DeathNotifier.java
@@ -25,7 +25,7 @@ public class DeathNotifier extends BaseNotifier {
         MessageBuilder messageBuilder = MessageBuilder.textAsEmbed(notifyMessage, plugin.config.deathSendImage());
         String thumbnailUrl = deathThumbNail().getThumbnailUrl();
         if (thumbnailUrl != null) {
-            messageBuilder.webhookBody.getEmbeds().stream().findFirst().ifPresent((embed -> embed.setThumbnail(new Image(thumbnailUrl))));
+            messageBuilder.setFirstThumbnail(new Image(thumbnailUrl));
         }
         plugin.messageHandler.sendMessage(messageBuilder);
 

--- a/src/main/java/universalDiscord/notifiers/DeathNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/DeathNotifier.java
@@ -1,5 +1,6 @@
 package universalDiscord.notifiers;
 
+import net.runelite.api.Player;
 import net.runelite.api.events.ActorDeath;
 import universalDiscord.UniversalDiscordPlugin;
 import universalDiscord.Utils;
@@ -30,7 +31,8 @@ public class DeathNotifier extends BaseNotifier {
     public boolean shouldNotify() {
         return isEnabled()
                 && lastActorDeath != null
-                && Objects.equals(lastActorDeath.getActor().getName(), Utils.getPlayerName());
+                && lastActorDeath.getActor() instanceof Player
+                && Objects.equals(((Player) lastActorDeath.getActor()).getId(), plugin.client.getLocalPlayer().getId());
     }
 
     @Override

--- a/src/main/java/universalDiscord/notifiers/LevelNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/LevelNotifier.java
@@ -49,7 +49,7 @@ public class LevelNotifier extends BaseNotifier {
 
         MessageBuilder messageBuilder = MessageBuilder.textAsEmbed(fullNotification, plugin.config.levelSendImage());
         SkillThumbnail finalSkillThumb = skillThumb;
-        messageBuilder.webhookBody.getEmbeds().stream().findFirst().ifPresent((embed -> embed.setThumbnail(new Image(finalSkillThumb.getThumbnailUrl()))));
+        messageBuilder.setFirstThumbnail(new Image(finalSkillThumb.getThumbnailUrl()));
         plugin.messageHandler.sendMessage(messageBuilder);
 
         reset();

--- a/src/main/java/universalDiscord/notifiers/LevelNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/LevelNotifier.java
@@ -3,7 +3,9 @@ package universalDiscord.notifiers;
 import lombok.extern.slf4j.Slf4j;
 import universalDiscord.UniversalDiscordPlugin;
 import universalDiscord.Utils;
+import universalDiscord.enums.SkillThumbnail;
 import universalDiscord.message.MessageBuilder;
+import universalDiscord.message.discord.Image;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -26,9 +28,12 @@ public class LevelNotifier extends BaseNotifier {
     public void handleNotify() {
         StringBuilder skillMessage = new StringBuilder();
         int index = 0;
+        SkillThumbnail skillThumb = SkillThumbnail.OVERALL;
 
         for (String skill : levelledSkills) {
+            skillThumb = SkillThumbnail.valueOf(skill.toUpperCase());
             if (index == levelledSkills.size()) {
+                skillThumb = SkillThumbnail.OVERALL;
                 skillMessage.append(" and ");
             } else if (index > 0) {
                 skillMessage.append(", ");
@@ -43,6 +48,8 @@ public class LevelNotifier extends BaseNotifier {
                 .replaceAll("%SKILL%", skillString);
 
         MessageBuilder messageBuilder = MessageBuilder.textAsEmbed(fullNotification, plugin.config.levelSendImage());
+        SkillThumbnail finalSkillThumb = skillThumb;
+        messageBuilder.webhookBody.getEmbeds().stream().findFirst().ifPresent((embed -> embed.setThumbnail(new Image(finalSkillThumb.getThumbnailUrl()))));
         plugin.messageHandler.sendMessage(messageBuilder);
 
         reset();

--- a/src/main/java/universalDiscord/notifiers/LootNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/LootNotifier.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 
 public class LootNotifier extends BaseNotifier {
-    final public Pattern CLUE_NAME_REGEX = Pattern.compile("Clue Scroll (\\w)");
+    final public Pattern CLUE_NAME_REGEX = Pattern.compile("Clue Scroll \\(\\w\\)");
 
     private Collection<ItemStack> receivedLoot;
     private String dropper;

--- a/src/main/java/universalDiscord/notifiers/LootNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/LootNotifier.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 
 public class LootNotifier extends BaseNotifier {
-    final public Pattern CLUE_NAME_REGEX = Pattern.compile("Clue Scroll \\(\\w\\)");
+    final public Pattern CLUE_NAME_REGEX = Pattern.compile("Clue Scroll \\(\\w+\\)");
 
     private Collection<ItemStack> receivedLoot;
     private String dropper;

--- a/src/main/java/universalDiscord/notifiers/QuestNotifier.java
+++ b/src/main/java/universalDiscord/notifiers/QuestNotifier.java
@@ -8,6 +8,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import universalDiscord.UniversalDiscordPlugin;
 import universalDiscord.Utils;
 import universalDiscord.message.MessageBuilder;
+import universalDiscord.message.discord.Image;
 import universalDiscord.notifiers.onevent.WidgetLoadHandler;
 
 import java.util.regex.Matcher;
@@ -33,7 +34,9 @@ public class QuestNotifier extends BaseNotifier implements WidgetLoadHandler {
         String notifyMessage = Utils.replaceCommonPlaceholders(plugin.config.questNotifyMessage())
                 .replaceAll("%QUEST%", Utils.asMarkdownWikiUrl(parseQuestWidget(lastQuestText)));
 
-        plugin.messageHandler.sendMessage(MessageBuilder.textAsEmbed(notifyMessage, plugin.config.questSendImage()));
+        MessageBuilder messageBuilder = MessageBuilder.textAsEmbed(notifyMessage, plugin.config.questSendImage());
+        messageBuilder.setFirstThumbnail(new Image("https://oldschool.runescape.wiki/images/Quests.png"));
+        plugin.messageHandler.sendMessage(messageBuilder);
 
         reset();
     }

--- a/src/test/java/universalDiscord/CollectionNotifierTest.java
+++ b/src/test/java/universalDiscord/CollectionNotifierTest.java
@@ -15,7 +15,7 @@ public class CollectionNotifierTest {
     @Test
     public void testCollectionLogRegex() {
         String[] itemNames = {
-                "Xerics talisman",
+                "Xeric's talisman (inert)",
                 "Jar of miasma",
                 "Saradomin's light",
                 "Craw's bow",

--- a/src/test/java/universalDiscord/CollectionNotifierTest.java
+++ b/src/test/java/universalDiscord/CollectionNotifierTest.java
@@ -1,0 +1,38 @@
+package universalDiscord;
+
+import org.junit.Test;
+import universalDiscord.notifiers.CollectionNotifier;
+
+import java.util.regex.Matcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class CollectionNotifierTest {
+
+
+    @Test
+    public void testCollectionLogRegex() {
+        String[] itemNames = {
+                "Xerics talisman",
+                "Jar of miasma",
+                "Saradomin's light",
+                "Craw's bow",
+                "Thammaron's sceptre",
+                "Chompy bird hat (ogre yeoman)",
+                "Robe bottoms of the eye",
+                "Bucket helm (g)",
+                "Black d'hide body (g)",
+                "Tzhaar-ket-om ornament kit",
+        };
+
+        for (String itemName : itemNames) {
+            String chatLine = "New item added to your collection log: " + itemName;
+            Matcher matcher = CollectionNotifier.COLLECTION_LOG_REGEX.matcher(chatLine);
+            boolean finds = matcher.find();
+            assertTrue(finds);
+            assertEquals(itemName, matcher.group("itemName"));
+        }
+    }
+}


### PR DESCRIPTION
When ClueNotifier(upper notification) and LootNotifier(bottom notification) are enabled, they both create a notification.
![image](https://user-images.githubusercontent.com/17124771/202768338-6d729dab-0a4f-4345-8a0b-10c1414f5887.png)
My fix now only allows the clue notifier to post clue notifications. LootNotifier now ignores all clue loot drops.